### PR TITLE
move themes to resources

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('css')
 	<style type="text/css">
-		
+
 		#themes{
 			margin-top:20px;
 		}
@@ -152,7 +152,7 @@
 
 @section('content')
 
-<div id="themes">	
+<div id="themes">
 
 	<div class="container-fluid">
 
@@ -164,19 +164,19 @@
         @if(count($themes) < 1)
 	        <div class="alert alert-warning">
 	            <strong>Wuh oh!</strong>
-	            <p>It doesn't look like you have any themes available in your theme folder located at <code><?= public_path('themes'); ?></code></p>
+	            <p>It doesn't look like you have any themes available in your theme folder located at <code><?= resource_path('views/themes'); ?></code></p>
 	        </div>
 	    @endif
 
         <div class="panel">
         	<div class="panel-body">
-        		
+
         		<div class="row">
 
         			@if(count($themes) < 1)
         				<div class="col-md-12">
         					<h2>No Themes Found</h2>
-        					<p>That's ok, you can download a <a href="https://github.com/thedevdojo/sample-theme" target="_blank">sample theme here</a>, or download the <a href="https://github.com/thedevdojo/pages" target="_blank">default pages here</a>. Make sure to download the theme and place it in your themes folder.</p> 
+        					<p>That's ok, you can download a <a href="https://github.com/thedevdojo/sample-theme" target="_blank">sample theme here</a>, or download the <a href="https://github.com/thedevdojo/pages" target="_blank">default pages here</a>. Make sure to download the theme and place it in your themes folder.</p>
         				</div>
         			@endif
 
@@ -195,8 +195,8 @@
 		        					@endif
 		        					<a href="{{ route('voyager.theme.options', $theme->folder) }}" class="voyager-params theme-options"></a>
 		        					<div class="voyager-trash theme-options-trash" data-id="{{ $theme->id }}"></div>
-		        					
-		        					
+
+
 		        				</div>
 		        			</div>
 	        			</div>
@@ -233,7 +233,6 @@
     </div><!-- /.modal -->
 
 </div>
-	
 
 @endsection
 

--- a/resources/views/options.blade.php
+++ b/resources/views/options.blade.php
@@ -42,7 +42,7 @@
 
 @section('content')
 
-<div id="theme_options">	
+<div id="theme_options">
 
 	<div class="container-fluid">
 
@@ -53,11 +53,11 @@
 
         <div class="panel">
         	<div class="panel-body">
-        		
-	        		@if(file_exists(public_path('themes') . '/' . $theme->folder . '/options.blade.php'))
+
+	        		@if(file_exists(resource_path('view/themes') . '/' . $theme->folder . '/options.blade.php'))
 	        			<?php define("ACTIVE_THEME_FOLDER", $theme->folder); ?>
 	        			<form action="{{ route('voyager.theme.options', $theme->folder) }}" method="POST" enctype="multipart/form-data">
-	        				
+
 	        				@include('themes_folder::' . $theme->folder . '.options')
 	        				{{ csrf_field() }}
 	        				<button class="btn btn-success">Save Theme Settings</button>
@@ -72,14 +72,14 @@
     </div>
 
 </div>
-	
+
 
 @endsection
 
 @section('javascript')
 	<script>
 		$('document').ready(function(){
-			
+
 		});
 	</script>
 @endsection

--- a/resources/views/options.blade.php
+++ b/resources/views/options.blade.php
@@ -54,7 +54,7 @@
         <div class="panel">
         	<div class="panel-body">
 
-	        		@if(file_exists(resource_path('view/themes') . '/' . $theme->folder . '/options.blade.php'))
+	        		@if(file_exists(resource_path('views/themes') . '/' . $theme->folder . '/options.blade.php'))
 	        			<?php define("ACTIVE_THEME_FOLDER", $theme->folder); ?>
 	        			<form action="{{ route('voyager.theme.options', $theme->folder) }}" method="POST" enctype="multipart/form-data">
 

--- a/src/Http/Controllers/ThemesController.php
+++ b/src/Http/Controllers/ThemesController.php
@@ -23,10 +23,10 @@ class ThemesController extends Controller
 
     private function getThemesFromFolder(){
     	$themes = array();
-        $theme_folder = public_path('themes');
+        $theme_folder = resource_path('views/themes');
 
         if(!file_exists($theme_folder)){
-            mkdir(public_path('themes'));
+            mkdir(resource_path('views/themes'));
         }
 
         $scandirectory = scandir($theme_folder);
@@ -108,8 +108,8 @@ class ThemesController extends Controller
         $theme_name = $theme->name;
 
         // if the folder exists delete it
-        if(file_exists(public_path($theme->folder))){
-            File::deleteDirectory(public_path($theme->folder), true);
+        if(file_exists(resource_path('views/themes/'.$theme->folder))){
+            File::deleteDirectory(resource_path('views/themes/'.$theme->folder), false);
         }
 
         $theme->delete();

--- a/src/Http/Controllers/ThemesController.php
+++ b/src/Http/Controllers/ThemesController.php
@@ -15,7 +15,7 @@ class ThemesController extends Controller
 
         // Anytime the admin visits the theme page we will check if we
         // need to add any more themes to the database
-    	$this->addThemesToDB();
+    	$this->installThemes();
         $themes = Theme::all();
 
         return view('themes::index', compact('themes'));
@@ -48,7 +48,7 @@ class ThemesController extends Controller
         return (object)$themes;
     }
 
-    private function addThemesToDB(){
+    private function installThemes() {
 
         $themes = $this->getThemesFromFolder();
 

--- a/src/Http/Controllers/ThemesController.php
+++ b/src/Http/Controllers/ThemesController.php
@@ -3,9 +3,9 @@
 namespace VoyagerThemes\Http\Controllers;
 
 use Voyager;
-use Illuminate\Http\File;
 use Illuminate\Http\Request;
 use \VoyagerThemes\Models\Theme;
+use Illuminate\Support\Facades\File;
 use \VoyagerThemes\Models\ThemeOptions;
 use TCG\Voyager\Http\Controllers\Controller;
 

--- a/src/Http/Controllers/ThemesController.php
+++ b/src/Http/Controllers/ThemesController.php
@@ -58,12 +58,14 @@ class ThemesController extends Controller
     			// If the theme does not exist in the database, then update it.
     			if(!isset($theme_exists->id)){
                     $version = isset($theme->version) ? $theme->version : '';
-    				Theme::create(['name' => $theme->name, 'folder' => $theme->folder, 'version' => $version]);
+                    Theme::create(['name' => $theme->name, 'folder' => $theme->folder, 'version' => $version]);
+                    $this->publishAssets($theme->folder);
     			} else {
     				// If it does exist, let's make sure it's been updated
     				$theme_exists->name = $theme->name;
                     $theme_exists->version = isset($theme->version) ? $theme->version : '';
                     $theme_exists->save();
+                    $this->publishAssets($theme->folder);
     			}
     		}
     	}
@@ -110,6 +112,10 @@ class ThemesController extends Controller
         // if the folder exists delete it
         if(file_exists(resource_path('views/themes/'.$theme->folder))){
             File::deleteDirectory(resource_path('views/themes/'.$theme->folder), false);
+        }
+
+        if(file_exists(public_path('themes/'.$theme->folder))){
+            File::deleteDirectory(public_path('themes/'.$theme->folder), false);
         }
 
         $theme->delete();
@@ -196,5 +202,16 @@ class ThemesController extends Controller
 
     private function deactivateThemes(){
         Theme::query()->update(['active' => 0]);
+    }
+
+    private function publishAssets($theme) {
+        $theme_path = public_path('themes/'.$theme);
+
+        if(!file_exists($theme_path)){
+            mkdir($theme_path);
+        }
+
+        File::copyDirectory(resource_path('views/themes/'.$theme.'/assets'), public_path('themes/'.$theme));
+        File::copy(resource_path('views/themes/'.$theme.'/'.$theme.'.jpg'), public_path('themes/'.$theme.'/'.$theme.'.jpg'));
     }
 }

--- a/src/Http/Controllers/ThemesController.php
+++ b/src/Http/Controllers/ThemesController.php
@@ -2,18 +2,18 @@
 
 namespace VoyagerThemes\Http\Controllers;
 
+use Voyager;
+use Illuminate\Http\File;
 use Illuminate\Http\Request;
-use Illumniate\Http\File;
 use \VoyagerThemes\Models\Theme;
 use \VoyagerThemes\Models\ThemeOptions;
-use Voyager;
 use TCG\Voyager\Http\Controllers\Controller;
 
 class ThemesController extends Controller
 {
     public function index(){
 
-        // Anytime the admin visits the theme page we will check if we 
+        // Anytime the admin visits the theme page we will check if we
         // need to add any more themes to the database
     	$this->addThemesToDB();
         $themes = Theme::all();
@@ -28,11 +28,11 @@ class ThemesController extends Controller
         if(!file_exists($theme_folder)){
             mkdir(public_path('themes'));
         }
-        
+
         $scandirectory = scandir($theme_folder);
-        
+
         if(isset($scandirectory)){
-        	
+
             foreach($scandirectory as $folder){
             	//dd($theme_folder . '/' . $folder . '/' . $folder . '.json');
             	$json_file = $theme_folder . '/' . $folder . '/' . $folder . '.json';
@@ -44,7 +44,7 @@ class ThemesController extends Controller
             }
 
         }
-        
+
         return (object)$themes;
     }
 
@@ -72,7 +72,7 @@ class ThemesController extends Controller
     public function activate($theme_folder){
 
         $theme = Theme::where('folder', '=', $theme_folder)->first();
-        
+
         if(isset($theme->id)){
             $this->deactivateThemes();
             $theme->active = 1;
@@ -126,13 +126,13 @@ class ThemesController extends Controller
     public function options($theme_folder){
 
         $theme = Theme::where('folder', '=', $theme_folder)->first();
-        
+
         if(isset($theme->id)){
-            
+
             $options = [];
 
             return view('themes::options', compact('options', 'theme'));
-            
+
         } else {
             return redirect()
                 ->route("voyager.theme.index")
@@ -190,7 +190,7 @@ class ThemesController extends Controller
     {
         $length = strlen($needle);
 
-        return $length === 0 || 
+        return $length === 0 ||
         (substr($haystack, -$length) === $needle);
     }
 

--- a/src/VoyagerThemesServiceProvider.php
+++ b/src/VoyagerThemesServiceProvider.php
@@ -58,9 +58,9 @@ class VoyagerThemesServiceProvider extends ServiceProvider
 
         // Make sure we have an active theme
         if (isset($theme)) {
-            $this->loadViewsFrom(public_path('themes/'.$theme->folder), 'theme');
+            $this->loadViewsFrom(resource_path('views/themes/'.$theme->folder), 'theme');
         }
-        $this->loadViewsFrom(public_path('themes'), 'themes_folder');
+        $this->loadViewsFrom(resource_path('views/themes'), 'themes_folder');
     }
 
     /**

--- a/src/VoyagerThemesServiceProvider.php
+++ b/src/VoyagerThemesServiceProvider.php
@@ -60,7 +60,7 @@ class VoyagerThemesServiceProvider extends ServiceProvider
         if (isset($theme)) {
             $this->loadViewsFrom(resource_path('views/themes/'.$theme->folder), 'theme');
         }
-        $this->loadViewsFrom(resource_path('views/themes'), 'themes_folder');
+        $this->loadViewsFrom(resource_path('views/themes/'), 'themes_folder');
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,7 +4,7 @@
 if (!function_exists(theme_field)){
 
 	function theme_field($type, $key, $title, $content = '', $details = '', $placeholder = '', $required = 0){
-		
+
 		$theme = \VoyagerThemes\Models\Theme::where('folder', '=', ACTIVE_THEME_FOLDER)->first();
 
 		$option_exists = $theme->options->where('key', '=', $key)->first();
@@ -25,9 +25,16 @@ if (!function_exists(theme_field)){
 
 if (!function_exists(theme)){
 
-	function theme($key){
+	function theme($key, $default = ''){
 		$theme = \VoyagerThemes\Models\Theme::where('active', '=', 1)->first();
-		return $theme->options->where('key', '=', $key)->first()->value;
+
+		$value = $theme->options->where('key', '=', $key)->first();
+
+		if(isset($value)) {
+			return $value->value;
+		}
+
+		return $default;
 	}
 
 }


### PR DESCRIPTION
## In this PR:
- move themes to `resources/views`
- fix ability to delete themes 
- set a default value to null for theme options to keep pages from breaking on newly activated themes.
- publish theme `assets` directory as well as the `<theme>.jpg` file to the `public/themes/<theme>` directory when installing the theme(s)
- fixed some typos