### PR TITLE
Capture query exception

### DIFF
--- a/src/VoyagerThemesServiceProvider.php
+++ b/src/VoyagerThemesServiceProvider.php
@@ -52,7 +52,9 @@ class VoyagerThemesServiceProvider extends ServiceProvider
         $this->loadModels();
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'themes');
 
-        $theme = \VoyagerThemes\Models\Theme::where('active', '=', 1)->first();
+        $theme = rescue(function () {
+            return \VoyagerThemes\Models\Theme::where('active', '=', 1)->first();
+        });
 
         view()->share('theme', $theme);
 


### PR DESCRIPTION
This query is throwing an exception when you try to install a project that uses voyager-themes.

`\VoyagerThemes\Models\Theme::where('active', '=', 1)->first();`

The issue is we are trying to make a query on a table that doesn't exist yet.

